### PR TITLE
feat: electron bootstrap and UI enhancements

### DIFF
--- a/core/encode.ts
+++ b/core/encode.ts
@@ -28,7 +28,8 @@ const readline = require('readline');
 const SCRYPT = {
   N: parseInt(process.env.SCRYPT_N || (1 << 15), 10),
   r: parseInt(process.env.SCRYPT_r || 8, 10),
-  p: parseInt(process.env.SCRYPT_p || 1, 10),
+  // Use all CPU cores by default for better scrypt performance
+  p: parseInt(process.env.SCRYPT_p || String(os.cpus().length), 10),
   keyLen: 32
 };
 const FRAGMENT_TYPE = "GitZipQR-CHUNK-ENC";

--- a/electron.js
+++ b/electron.js
@@ -1,0 +1,25 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 900,
+    height: 700,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+  win.loadFile(path.join(__dirname, 'frontend/index.html'));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -1,27 +1,57 @@
 body {
-  font-family: Arial, sans-serif;
-  background: #f0f0f0;
+  font-family: "Segoe UI", sans-serif;
+  background: linear-gradient(135deg, #1b2735, #090a0f);
+  color: #eee;
   display: flex;
   justify-content: center;
   align-items: center;
   height: 100vh;
   margin: 0;
 }
+
 .container {
-  background: white;
-  padding: 20px;
-  border-radius: 8px;
-  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+  background: rgba(0, 0, 0, 0.6);
+  padding: 30px;
+  border-radius: 12px;
+  box-shadow: 0 0 20px rgba(0,0,0,0.5);
+  text-align: center;
+  animation: fadeIn 0.5s ease-in-out;
 }
-.mode {
-  margin-bottom: 10px;
-}
-.file {
-  margin-bottom: 10px;
-}
-#passwords div {
-  margin-bottom: 5px;
-}
+
+.mode { margin-bottom: 10px; }
+.file { margin-bottom: 10px; }
+#passwords div { margin-bottom: 5px; }
+
 button {
   margin-right: 5px;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+button:hover { background: #005fa3; }
+
+.terminal {
+  background: #000;
+  color: #0f0;
+  padding: 10px;
+  height: 150px;
+  overflow: auto;
+  margin-top: 10px;
+  font-family: monospace;
+  border-radius: 4px;
+}
+
+.terminal .line {
+  opacity: 0;
+  animation: fadeIn 0.3s forwards;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(5px); }
+  to { opacity: 1; transform: translateY(0); }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,6 +19,7 @@
     <button id="addPassword">Add password</button>
     <button id="actionBtn">Start</button>
     <div id="output"></div>
+    <div id="terminal" class="terminal"></div>
   </div>
   <script src="index.js"></script>
 </body>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,6 +1,7 @@
 const passwordsDiv = document.getElementById('passwords');
 const fileInput = document.getElementById('fileInput');
 const output = document.getElementById('output');
+const terminal = document.getElementById('terminal');
 
 function addPasswordField() {
   const idx = passwordsDiv.querySelectorAll('input').length + 1;
@@ -20,5 +21,29 @@ document.getElementById('actionBtn').addEventListener('click', () => {
   const file = fileInput.files[0];
   const passwords = Array.from(passwordsDiv.querySelectorAll('input')).map(i => i.value);
   output.textContent = `${mode} with ${passwords.length} password(s)` + (file ? ` on ${file.name}` : '');
+  terminal.innerHTML = '';
+  const messages = [
+    `$ ${mode}${file ? ' ' + file.name : ''}`,
+    'STEP #1 zip ... [1]',
+    'STEP #2 encrypt ... [1]',
+    'STEP #3 chunk & queue jobs ... [1]',
+    'STEP #4 encode QR in parallel ... [1]',
+    'Done.'
+  ];
+  let idx = 0;
+  function log(msg) {
+    const line = document.createElement('div');
+    line.textContent = msg;
+    line.className = 'line';
+    terminal.appendChild(line);
+    terminal.scrollTop = terminal.scrollHeight;
+  }
+  function next() {
+    if (idx < messages.length) {
+      log(messages[idx++]);
+      setTimeout(next, 500);
+    }
+  }
+  next();
   // TODO: integrate with backend or CLI
 });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "type": "commonjs",
   "scripts": {
     "encode": "bun run core/encode.ts",
-    "decode": "bun run core/decode.ts"
+    "decode": "bun run core/decode.ts",
+    "desktop": "bunx electron electron.js"
   },
   "engines": {
     "node": ">=18"
@@ -23,5 +24,8 @@
     "jsqr": "^1.4.0",
     "pngjs": "^7.0.0",
     "qrcode": "^1.5.4"
+  },
+  "devDependencies": {
+    "electron": "^29.4.1"
   }
 }


### PR DESCRIPTION
## Summary
- add electron dev dependency and desktop script
- style frontend with dark theme and animated terminal output
- use all CPU cores by default for faster scrypt

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aaeb06d534832ab7921b6bc39727d2