### PR TITLE
feat: add decrypt mode and usdt support

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -109,3 +109,34 @@ ol {
   overflow-y: auto;
   text-align: left;
 }
+
+.mode-toggle {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.mode-toggle button {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  background: #444;
+  color: #fff;
+  cursor: pointer;
+}
+
+.mode-toggle button.active {
+  background: gold;
+  color: #000;
+}
+
+#supportBtn {
+  margin-top: 10px;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  background: #444;
+  color: #fff;
+  cursor: pointer;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,7 +29,11 @@
       </ol>
     </div>
     <section id="encryptSection" class="card">
-      <h2 data-i18n="encryptTitle">Encrypt File</h2>
+      <div class="mode-toggle">
+        <button id="modeEncrypt" class="active" data-i18n="modeEncrypt">Encrypt</button>
+        <button id="modeDecrypt" data-i18n="modeDecrypt">Decrypt</button>
+      </div>
+      <h2 id="modeTitle" data-i18n="encryptTitle">Encrypt File</h2>
       <div id="dropZone" class="drop-zone" data-i18n="dropText">Drop file here or click to select</div>
       <input type="file" id="fileInput" class="hidden" />
       <div class="passwords">
@@ -39,6 +43,7 @@
       <button id="addPassword" data-i18n="addPass">Add password</button>
       <button id="encryptBtn" data-i18n="encryptBtn">Encrypt</button>
       <pre id="terminal" class="terminal"></pre>
+      <button id="supportBtn" data-i18n="supportBtn">Support via USDT</button>
     </section>
   </main>
   <script src="index.js"></script>


### PR DESCRIPTION
## Summary
- add front-end toggle to switch between encryption and decryption
- preserve and restore file extension during browser decryption
- add USDT support button with copy-to-clipboard address

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab3325b4b8832aa9112080d0ba30f8