### PR TITLE
Add QR code export and UI polish

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -12,7 +12,11 @@ body {
 .top-bar {
   position: absolute;
   top: 10px;
+  left: 10px;
   right: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .lang-switch button {
@@ -139,4 +143,23 @@ ol {
   background: #444;
   color: #fff;
   cursor: pointer;
+}
+
+.gradient-text {
+  background: linear-gradient(45deg, #ff7e00, #ffe347);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.metamask-link {
+  background: linear-gradient(45deg, #f6851b, #ffcd4d);
+  color: #000;
+  padding: 6px 12px;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.metamask-link:hover {
+  opacity: 0.8;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,12 @@
   <meta charset="UTF-8">
   <title>GitZipQR</title>
   <link rel="stylesheet" href="index.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcode/1.5.1/qrcode.min.js"></script>
 </head>
 <body>
   <header class="top-bar">
+    <a id="metamaskLink" class="metamask-link" href="https://metamask.io" target="_blank">MetaMask</a>
     <div class="lang-switch">
       <button id="langBtn">Change language</button>
       <div id="langMenu" class="hidden">
@@ -17,7 +20,7 @@
   </header>
   <main>
     <div class="card">
-      <h1 data-i18n="title">GitZipQR</h1>
+      <h1 class="gradient-text" data-i18n="title">GitZipQR</h1>
       <p data-i18n="tagline">Secure archives through QR-coded encryption</p>
       <p data-i18n="intro">GitZipQR turns a folder into a deterministic ZIP, encrypts it with AES-256-GCM and stores the ciphertext inside QR codes.</p>
       <ol>


### PR DESCRIPTION
## Summary
- Download QR code archive during encryption
- Hide USDT address and add MetaMask support link
- Apply gradient styling to headings and header

## Testing
- `npm run encode` (fails: Cannot find package 'archiver')
- `npm install` (fails: 403 Forbidden fetching jszip)

------
https://chatgpt.com/codex/tasks/task_e_68ab34ebeab0832a98b1b73dc323ba9e