### PR TITLE
Add folder support to web QR encoder/decoder

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="index.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcode/1.5.1/qrcode.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jsqr/1.4.0/jsQR.min.js"></script>
 </head>
 <body>
   <header class="top-bar">
@@ -36,9 +37,9 @@
         <button id="modeEncrypt" class="active" data-i18n="modeEncrypt">Encrypt</button>
         <button id="modeDecrypt" data-i18n="modeDecrypt">Decrypt</button>
       </div>
-      <h2 id="modeTitle" data-i18n="encryptTitle">Encrypt File</h2>
-      <div id="dropZone" class="drop-zone" data-i18n="dropText">Drop file here or click to select</div>
-      <input type="file" id="fileInput" class="hidden" />
+      <h2 id="modeTitle" data-i18n="encryptTitle">Encrypt Folder</h2>
+      <div id="dropZone" class="drop-zone" data-i18n="dropText">Drop folder here or click to select</div>
+      <input type="file" id="fileInput" class="hidden" webkitdirectory multiple />
       <div class="passwords">
         <input type="password" class="password-field" placeholder="Password #1">
         <input type="password" class="password-field" placeholder="Password #2">

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -8,9 +8,9 @@ const translations = {
     step3: "Split the ciphertext into QR-sized chunks",
     step4: "Embed each chunk directly into a QR image (base64 payload)",
     step5: "To restore, scan all QR codes and decrypt using the same password",
-    encryptTitle: "Encrypt File",
-    decryptTitle: "Decrypt File",
-    dropText: "Drop file here or click to select",
+    encryptTitle: "Encrypt Folder",
+    decryptTitle: "Decrypt Folder",
+    dropText: "Drop folder here or click to select",
     addPass: "Add password",
     encryptBtn: "Encrypt",
     decryptBtn: "Decrypt",
@@ -27,9 +27,9 @@ const translations = {
     step3: "Разделите шифртекст на части размером с QR-код",
     step4: "Встроите каждую часть непосредственно в изображение QR (base64)",
     step5: "Для восстановления отсканируйте все QR-коды и расшифруйте тем же паролем",
-    encryptTitle: "Зашифровать файл",
-    decryptTitle: "Расшифровать файл",
-    dropText: "Перетащите файл сюда или нажмите для выбора",
+    encryptTitle: "Зашифровать папку",
+    decryptTitle: "Расшифровать папку",
+    dropText: "Перетащите папку сюда или нажмите для выбора",
     addPass: "Добавить пароль",
     encryptBtn: "Зашифровать",
     decryptBtn: "Расшифровать",
@@ -81,11 +81,47 @@ const modeDecrypt = document.getElementById('modeDecrypt');
 const modeTitle = document.getElementById('modeTitle');
 const supportBtn = document.getElementById('supportBtn');
 let mode = 'encrypt';
-let selectedFile = null;
+let selectedFiles = [];
 
 function log(msg) {
   terminal.textContent += msg + '\n';
   terminal.scrollTop = terminal.scrollHeight;
+}
+
+async function traverseFileTree(entry, path = '') {
+  return new Promise((resolve, reject) => {
+    if (entry.isFile) {
+      entry.file(file => {
+        file.relativePath = path + file.name;
+        resolve([file]);
+      }, reject);
+    } else if (entry.isDirectory) {
+      const dirReader = entry.createReader();
+      dirReader.readEntries(async entries => {
+        const promises = entries.map(e => traverseFileTree(e, path + entry.name + '/'));
+        const results = await Promise.all(promises);
+        resolve(results.flat());
+      }, reject);
+    } else {
+      resolve([]);
+    }
+  });
+}
+
+async function getFilesFromItems(items) {
+  let all = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const entry = item.webkitGetAsEntry ? item.webkitGetAsEntry() : null;
+    if (entry) {
+      const files = await traverseFileTree(entry);
+      all = all.concat(files);
+    } else {
+      const f = item.getAsFile();
+      if (f) all.push(f);
+    }
+  }
+  return all;
 }
 
 dropZone.addEventListener('click', () => fileInput.click());
@@ -97,22 +133,20 @@ dropZone.addEventListener('dragover', (e) => {
 
 dropZone.addEventListener('dragleave', () => dropZone.classList.remove('hover'));
 
-dropZone.addEventListener('drop', (e) => {
+dropZone.addEventListener('drop', async (e) => {
   e.preventDefault();
   dropZone.classList.remove('hover');
-  const f = e.dataTransfer.files[0];
-  if (f) {
-    selectedFile = f;
-    log('File selected: ' + f.name);
+  if (e.dataTransfer.items) {
+    selectedFiles = await getFilesFromItems(e.dataTransfer.items);
+  } else {
+    selectedFiles = Array.from(e.dataTransfer.files);
   }
+  log('Files selected: ' + selectedFiles.length);
 });
 
 fileInput.addEventListener('change', (e) => {
-  const f = e.target.files[0];
-  if (f) {
-    selectedFile = f;
-    log('File selected: ' + f.name);
-  }
+  selectedFiles = Array.from(e.target.files);
+  log('Files selected: ' + selectedFiles.length);
 });
 
 addPassword.addEventListener('click', () => {
@@ -136,23 +170,26 @@ function setMode(m) {
 modeEncrypt.addEventListener('click', () => setMode('encrypt'));
 modeDecrypt.addEventListener('click', () => setMode('decrypt'));
 
-async function encryptFile() {
-  if (!selectedFile) { log('No file selected'); return; }
+async function encryptFolder() {
+  if (!selectedFiles.length) { log('No files selected'); return; }
   const pwEls = passwordsDiv.querySelectorAll('input');
   const pw = Array.from(pwEls).map(i => i.value).filter(Boolean).join('\u0000');
   if (!pw) { log('No passwords provided'); return; }
-  log('Encrypting ' + selectedFile.name + ' ...');
+  log('Encrypting folder ...');
   try {
-    const data = new Uint8Array(await selectedFile.arrayBuffer());
+    const zipSrc = new JSZip();
+    for (const file of selectedFiles) {
+      const path = file.webkitRelativePath || file.relativePath || file.name;
+      zipSrc.file(path, file);
+    }
+    const zipped = await zipSrc.generateAsync({ type: 'uint8array' });
     const enc = new TextEncoder();
     const pwKey = await crypto.subtle.importKey('raw', enc.encode(pw), 'PBKDF2', false, ['deriveKey']);
     const salt = crypto.getRandomValues(new Uint8Array(16));
     const key = await crypto.subtle.deriveKey({ name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' }, pwKey, { name: 'AES-GCM', length: 256 }, false, ['encrypt']);
     const iv = crypto.getRandomValues(new Uint8Array(12));
-    const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
-    const ext = selectedFile.name.split('.').pop() || '';
-    const extBytes = new TextEncoder().encode(ext);
-    if (extBytes.length > 255) { log('Extension too long'); return; }
+    const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, zipped);
+    const extBytes = new TextEncoder().encode('zip');
     const out = new Uint8Array(1 + extBytes.length + salt.length + iv.length + cipher.byteLength);
     let offset = 0;
     out[offset++] = extBytes.length;
@@ -171,7 +208,7 @@ async function encryptFile() {
     const base64 = toBase64(out);
     const chunkSize = 2500;
     const zip = new JSZip();
-    const folder = zip.folder('QR-коды');
+    const folder = zip.folder('QR-codes');
     let count = 0;
     for (let i = 0; i < base64.length; i += chunkSize) {
       const chunk = base64.slice(i, i + chunkSize);
@@ -181,21 +218,57 @@ async function encryptFile() {
     const content = await zip.generateAsync({ type: 'blob' });
     const a = document.createElement('a');
     a.href = URL.createObjectURL(content);
-    a.download = 'swapinterfaces.zip';
+    a.download = 'qrcodes.zip';
     a.click();
     log('Encryption complete. QR codes: ' + count);
   } catch (e) {
     log('Error: ' + e.message);
   }
 }
-async function decryptFile() {
-  if (!selectedFile) { log('No file selected'); return; }
+
+async function fileToImageData(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width;
+        canvas.height = img.height;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0);
+        resolve(ctx.getImageData(0, 0, img.width, img.height));
+      };
+      img.onerror = reject;
+      img.src = reader.result;
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+function fromBase64(b64) {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function decryptFolder() {
+  if (!selectedFiles.length) { log('No files selected'); return; }
   const pwEls = passwordsDiv.querySelectorAll('input');
   const pw = Array.from(pwEls).map(i => i.value).filter(Boolean).join('\u0000');
   if (!pw) { log('No passwords provided'); return; }
-  log('Decrypting ' + selectedFile.name + ' ...');
+  log('Decrypting folder ...');
   try {
-    const bytes = new Uint8Array(await selectedFile.arrayBuffer());
+    const files = selectedFiles.slice().sort((a,b)=>a.name.localeCompare(b.name));
+    let base64 = '';
+    for (const file of files) {
+      const img = await fileToImageData(file);
+      const code = jsQR(img.data, img.width, img.height);
+      if (code) base64 += code.data;
+    }
+    const bytes = fromBase64(base64);
     let offset = 0;
     const extLen = bytes[offset++];
     const ext = new TextDecoder().decode(bytes.slice(offset, offset + extLen));
@@ -207,12 +280,11 @@ async function decryptFile() {
     const pwKey = await crypto.subtle.importKey('raw', enc.encode(pw), 'PBKDF2', false, ['deriveKey']);
     const key = await crypto.subtle.deriveKey({ name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' }, pwKey, { name: 'AES-GCM', length: 256 }, false, ['decrypt']);
     const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, cipher);
-    const blob = new Blob([plain]);
     const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = 'decoded' + (ext ? '.' + ext : '');
+    a.href = URL.createObjectURL(new Blob([plain]));
+    a.download = 'decoded.zip';
     a.click();
-    log('Decryption complete. Extension: ' + (ext ? '.' + ext : 'none'));
+    log('Decryption complete. Extension: .' + ext);
   } catch (e) {
     log('Error: ' + e.message);
   }
@@ -226,8 +298,8 @@ supportBtn.addEventListener('click', () => {
 });
 
 actionBtn.addEventListener('click', () => {
-  if (mode === 'encrypt') encryptFile();
-  else decryptFile();
+  if (mode === 'encrypt') encryptFolder();
+  else decryptFolder();
 });
 
 setMode('encrypt');


### PR DESCRIPTION
## Summary
- Support dragging or selecting directories for encryption/decryption in the web UI
- Generate QR codes from zipped folders and decode them back using jsQR
- Update translations and interface copy to focus on folders instead of single files

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab36a3a5f8832abe725caa92b33bde