### PR TITLE
Add SDK and file-aware encode/decode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM oven/bun:1.1-alpine
 WORKDIR /app
 
-# Манифесты + зависимости
+# install dependencies
 COPY package*.json tsconfig.json ./
 RUN bun install --frozen-lockfile || bun install
 
-# Код проекта
+# project source
 COPY . .
 
-# By default show encoder usage
-CMD ["bun","run","core/encode.ts"]
+ENTRYPOINT ["bun","run"]
+CMD ["encode"]

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -1,0 +1,26 @@
+const { encode } = require('../core/encode');
+const { decode } = require('../core/decode');
+
+/**
+ * Programmatic encode.
+ * @param {string} input Path to file or directory to encode.
+ * @param {string[]} passwords Array of passwords.
+ * @param {string} [outputDir=process.cwd()] Output directory.
+ * @returns {Promise<{qrDir:string,fileId:string,totalChunks:number,archiveName:string}>}
+ */
+async function sdkEncode(input, passwords, outputDir = process.cwd()) {
+  return await encode(input, outputDir, passwords);
+}
+
+/**
+ * Programmatic decode.
+ * @param {string} input Path to QR images or fragments.
+ * @param {string[]} passwords Array of passwords.
+ * @param {string} [outputDir=process.cwd()] Output directory.
+ * @returns {Promise<string>} Path to restored file.
+ */
+async function sdkDecode(input, passwords, outputDir = process.cwd()) {
+  return await decode(input, outputDir, passwords);
+}
+
+module.exports = { encode: sdkEncode, decode: sdkDecode };


### PR DESCRIPTION
## Summary
- add programmatic SDK with encode/decode helpers
- allow encoding single files and restore with original extension
- update Dockerfile and README

## Testing
- `npm_config_registry=https://registry.npmjs.org bun install` *(fails: GET jszip - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0728d958832aba0e0818e747ea3f