### PR TITLE
Simplify QR output and translate comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker build -t gitzipqr .
 # encode inside container (entrypoint is `bun run`)
 docker run -it --rm -v $(pwd):/data gitzipqr encode /data/example.txt /data/out
 # decode
-docker run -it --rm -v $(pwd):/data gitzipqr decode /data/out/qrcodes /data/restore
+docker run -it --rm -v $(pwd):/data gitzipqr decode /data/out /data/restore
 ```
 
 # Example Encode
@@ -103,7 +103,7 @@ echo "Hello World" > hello.txt
 bun encode ./hello.txt ./crypto
 
 # 3) Inspect outputs
-ls -1 ./crypto/qrcodes | head -n 5
+ls -1 ./crypto | head -n 5
 ```
 
 Generate the additional watermark QR independently:
@@ -116,7 +116,7 @@ Example Decode
 ```bash
 # 4) Decode from QR images → restored file in ./restore
 mkdir -p restore
-bun decode ./crypto/qrcodes ./restore
+bun decode ./crypto ./restore
 
 # 5) Restored file is available with original name
 cat ./restore/hello.txt
@@ -139,7 +139,7 @@ const { encode, decode } = require('./sdk');
 
 (async () => {
   await encode('hello.txt', ['mySecret'], './crypto');
-  await decode('./crypto/qrcodes', ['mySecret'], './restore');
+  await decode('./crypto', ['mySecret'], './restore');
 })();
 ```
 ⚡ Performance Notes

--- a/core/decode.ts
+++ b/core/decode.ts
@@ -85,8 +85,8 @@ async function decode(inputPath, outputDir=process.cwd(), passwords){
   // STEP 1: collect
   stepStart(1,'collect data');
   let chunks=[];
-  let nameBase=null;   // БЕЗ расширения
-  let metaExt=null;    // С расширением (".zip", ".png", ...)
+  let nameBase=null;   // without extension
+  let metaExt=null;    // with extension (".zip", ".png", ...)
   let cipherSha256=null, expectedTotal=null, kdf=null, salt=null, nonce=null;
 
   if(fs.existsSync(input) && fs.statSync(input).isDirectory()){
@@ -183,7 +183,7 @@ async function decode(inputPath, outputDir=process.cwd(), passwords){
     stepDone(1);
   } catch { stepDone(0); console.error("Decryption failed. Wrong password or corrupted data."); process.exit(1); }
 
-  // STEP 4: write as <name><ext> (ext может быть пустым — тогда без расширения)
+  // STEP 4: write as <name><ext> (ext may be empty — then no extension)
   stepStart(4,'write output');
   let ext = String(metaExt || '');
   if(ext && !ext.startsWith('.')) ext = '.'+ext;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,7 +15,6 @@
       <button id="langBtn">Change language</button>
       <div id="langMenu" class="hidden">
         <button data-lang="en">English</button>
-        <button data-lang="ru">Русский</button>
       </div>
     </div>
   </header>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -17,27 +17,7 @@ const translations = {
     modeEncrypt: "Encrypt",
     modeDecrypt: "Decrypt",
     supportBtn: "Support via USDT",
-    walletLabel: "USDT Wallet:"
-  },
-  ru: {
-    title: "GitZipQR",
-    tagline: "Безопасные архивы через QR-коды",
-    intro: "GitZipQR превращает папку в детерминированный ZIP, шифрует его AES-256-GCM и сохраняет шифртекст внутри QR-кодов.",
-    step1: "Архивируйте папку с нормализованными отметками времени",
-    step2: "Получите ключ через scrypt и зашифруйте AES-256-GCM",
-    step3: "Разделите шифртекст на части размером с QR-код",
-    step4: "Встроите каждую часть непосредственно в изображение QR (base64)",
-    step5: "Для восстановления отсканируйте все QR-коды и расшифруйте тем же паролем",
-    encryptTitle: "Зашифровать папку",
-    decryptTitle: "Расшифровать папку",
-    dropText: "Перетащите папку или ZIP сюда или нажмите для выбора",
-    addPass: "Добавить пароль",
-    encryptBtn: "Зашифровать",
-    decryptBtn: "Расшифровать",
-    modeEncrypt: "Шифровать",
-    modeDecrypt: "Расшифровать",
-    supportBtn: "Поддержать USDT",
-    walletLabel: "USDT кошелек:"
+    walletLabel: "USDT Wallet:",
   }
 };
 
@@ -265,12 +245,11 @@ async function encryptFolder() {
       }
     }
     const zip = new JSZip();
-    const folder = zip.folder('QR-codes');
     let count = 0;
     for (let i = 0; i < base64.length; i += chunkSize) {
       const chunk = base64.slice(i, i + chunkSize);
       const dataUrl = await QRCode.toDataURL(chunk, { errorCorrectionLevel: 'L' });
-      folder.file(`qr-${++count}.png`, dataUrl.split(',')[1], { base64: true });
+      zip.file(`qr-${++count}.png`, dataUrl.split(',')[1], { base64: true });
     }
     const content = await zip.generateAsync({ type: 'blob' });
     const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- Translate encoder/decoder comments to English
- Output QR images directly to chosen folder and remove nested subfolder
- Strip Russian UI code and simplify frontend QR packaging

## Testing
- `npm test` *(fails: Missing script "test")*
- `bun -e "import('./core/encode.ts').then(m=>m.encode('README.md','./tmp_qr',['password123']).then(()=>console.log('encode ok')).catch(e=>console.error(e))).catch(e=>console.error(e));"` *(fails: Cannot find package 'archiver')*


------
https://chatgpt.com/codex/tasks/task_e_68ac2df34610832ab066a2af1b720f12