### PR TITLE
Handle QR image decoding by content, not extension

### DIFF
--- a/core/decode.ts
+++ b/core/decode.ts
@@ -48,8 +48,6 @@ async function promptPasswords(defaultCount=2){
   }
   return parts.join('\u0000');
 }
-
-function isImageFile(name){ return /\.(png|jpg|jpeg)$/i.test(name); }
 function listFragmentsFlexible(p){
   const st = fs.existsSync(p) ? fs.statSync(p) : null;
   if(st && st.isFile()) return [path.resolve(p)];
@@ -90,7 +88,9 @@ async function decode(inputPath, outputDir=process.cwd(), passwords){
   let cipherSha256=null, expectedTotal=null, kdf=null, salt=null, nonce=null;
 
   if(fs.existsSync(input) && fs.statSync(input).isDirectory()){
-    const imgs = fs.readdirSync(input).filter(isImageFile).map(f=>path.join(input,f));
+    const imgs = fs.readdirSync(input)
+      .map(f=>path.join(input,f))
+      .filter(f=>fs.statSync(f).isFile());
     if(imgs.length){
       const results = await runDecodePool(imgs);
       const acc = new Map();

--- a/core/qrdecode.worker.ts
+++ b/core/qrdecode.worker.ts
@@ -10,12 +10,16 @@ const jsQR = require('jsqr');
 
 function readRGBA(filePath) {
   const buf = fs.readFileSync(filePath);
-  if (/\.png$/i.test(filePath)) {
+  const isPng = buf.slice(0,8).equals(Buffer.from('89504e470d0a1a0a','hex'));
+  const isJpeg = buf[0] === 0xff && buf[1] === 0xd8;
+  if (isPng) {
     const png = PNG.sync.read(buf);
     return { data: png.data, width: png.width, height: png.height };
-  } else {
+  } else if (isJpeg) {
     const raw = jpeg.decode(buf, { useTArray: true });
     return { data: raw.data, width: raw.width, height: raw.height };
+  } else {
+    throw new Error('Unsupported image format');
   }
 }
 


### PR DESCRIPTION
## Summary
- Decode QR images regardless of file extension by reading all files
- Detect PNG vs JPEG via magic bytes instead of filename

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac314c8128832ab9fcd247c625b4c3