### PR TITLE
Validate file paths in C++ encoder and decoder

### DIFF
--- a/core/decode.cpp
+++ b/core/decode.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
+#include <filesystem>
 
 int main(int argc, char* argv[]) {
     if (argc < 3) {
@@ -11,6 +12,16 @@ int main(int argc, char* argv[]) {
     }
     std::string inPath = argv[1];
     std::string outPath = argv[2];
+
+    namespace fs = std::filesystem;
+    if (!fs::exists(inPath) || fs::is_directory(inPath)) {
+        std::cerr << "Input path must be a regular file" << std::endl;
+        return 1;
+    }
+    if (fs::exists(outPath) && fs::is_directory(outPath)) {
+        std::cerr << "Output path cannot be a directory" << std::endl;
+        return 1;
+    }
 
     std::cout << "Password: ";
     std::string password;

--- a/core/encode.cpp
+++ b/core/encode.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
+#include <filesystem>
 
 int main(int argc, char* argv[]) {
     if (argc < 3) {
@@ -12,6 +13,16 @@ int main(int argc, char* argv[]) {
     }
     std::string inPath = argv[1];
     std::string outPath = argv[2];
+
+    namespace fs = std::filesystem;
+    if (!fs::exists(inPath) || fs::is_directory(inPath)) {
+        std::cerr << "Input path must be a regular file" << std::endl;
+        return 1;
+    }
+    if (fs::exists(outPath) && fs::is_directory(outPath)) {
+        std::cerr << "Output path cannot be a directory" << std::endl;
+        return 1;
+    }
 
     std::cout << "Password: ";
     std::string password;


### PR DESCRIPTION
## Summary
- ensure encoder and decoder verify that input is a regular file and output isn't a directory
- avoid crashes when directory paths are supplied

## Testing
- `make`
- `bin/decode edd/ s <<'EOF'
password123
EOF`
- `bin/encode edd/ out.bin <<'EOF'
password123
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68afefd3ac24832abc2679724d2730fa